### PR TITLE
Add typesense path option

### DIFF
--- a/scraper/src/typesense_helper.py
+++ b/scraper/src/typesense_helper.py
@@ -17,6 +17,7 @@ class TypesenseHelper:
             'nodes': [{
                 'host': os.environ.get('TYPESENSE_HOST', None),
                 'port': os.environ.get('TYPESENSE_PORT', None),
+                'path': os.environ.get('TYPESENSE_PATH', None),
                 'protocol': os.environ.get('TYPESENSE_PROTOCOL', None)
             }]
         })


### PR DESCRIPTION
## Change Summary
My search server is hosted under a path. With the current scraper, I can't get it to work.

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
