### PR TITLE
Include "Bot" token in default user agent string

### DIFF
--- a/scraper/src/config/config_loader.py
+++ b/scraper/src/config/config_loader.py
@@ -48,7 +48,7 @@ class ConfigLoader:
     strip_chars = u".,;:§¶"
     update_nb_hits = None
     use_anchors = False
-    user_agent = 'Algolia DocSearch Crawler'
+    user_agent = 'Typesense DocSearch Scraper (Bot; https://typesense.org/docs/guide/docsearch.html)'
     only_content_level = False
     query_rules = []
 


### PR DESCRIPTION
Reflect current branding and project name

Include URL for more information.

Include "Bot" token to help various traffic stats and aggregator tools to correctly categorise as spider/bot, even if it doesn't know about typesense-docsearch-scraper specifically. The most common token that these kinds of aggregator and analyzer tools look for is "bot".

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
