### PR TITLE
Fix link to the guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Think of it as an open source alternative to Algolia and an easier-to-use, batte
 
 ## Usage
 
-Read detailed step-by-step instructions on how to configure and setup the scraper on Typesense's dedicated documentation site: https://typesense.org/docs/latest/guide/docsearch.html
+Read detailed step-by-step instructions on how to configure and setup the scraper on Typesense's dedicated documentation site: https://typesense.org/docs/guide/docsearch.html
 
 ## Changelog
 


### PR DESCRIPTION
## Change Summary
The link to the docsearch guide in README is leading to 404, updating with the correct link.

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
