### PR TITLE
feat: add support for http_auth_domain spider attribute

### DIFF
--- a/scraper/src/documentation_spider.py
+++ b/scraper/src/documentation_spider.py
@@ -26,6 +26,7 @@ class DocumentationSpider(CrawlSpider, SitemapSpider):
     """
     http_user = os.environ.get('DOCSEARCH_BASICAUTH_USERNAME', None)
     http_pass = os.environ.get('DOCSEARCH_BASICAUTH_PASSWORD', None)
+    http_auth_domain = os.environ.get('DOCSEARCH_AUTH_DOMAIN', None)
     typesense_helper = None
     strategy = None
     js_render = False


### PR DESCRIPTION
See https://doc.scrapy.org/en/latest/topics/downloader-middleware.html#module-scrapy.downloadermiddlewares.httpauth

## Change Summary
Add the option to define the domain which requires the http authentication.

> In previous Scrapy versions HttpAuthMiddleware sent the authentication data with all requests, which is a security problem if the spider makes requests to several different domains. Currently if the http_auth_domain attribute is not set, the middleware will use the domain of the first request, which will work for some spiders but not for others. In the future the middleware will produce an error instead.