### PR TITLE
ci: change python semantic version to 3.10

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.x"
+          python-version: "3.10"
       - run: touch .env
       - run: |
           echo "TYPESENSE_API_KEY=xyz


### PR DESCRIPTION

## Change Summary
Avoid potential issues with pipenv having a 3.12 installation when the Pipfile mentions 3.10, like in #76 

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
