### PR TITLE
Able to set request[verify] via TYPESENSE_VERIFY

### DIFF
--- a/scraper/src/typesense_helper.py
+++ b/scraper/src/typesense_helper.py
@@ -25,6 +25,7 @@ class TypesenseHelper:
                     }
                 ],
                 'connection_timeout_seconds': 30 * 60,
+                'verify': os.environ.get('TYPESENSE_VERIFY', True),
             }
         )
         self.alias_name = alias_name


### PR DESCRIPTION
## Change Summary
Able to set `verify` option (code https://github.com/typesense/typesense-python/blob/master/src/typesense/request_handler.py#L90) via `TYPESENSE_VERIFY` env

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
