### PR TITLE
feat: add support for toggling enable_nested_fields in docsearch json

### DIFF
--- a/scraper/src/typesense_helper.py
+++ b/scraper/src/typesense_helper.py
@@ -153,6 +153,10 @@ class TypesenseHelper:
             if field_definitions is not None:
                 schema['fields'] = field_definitions
 
+            enable_nested_fields = self.custom_settings.get('enable_nested_fields', None)
+            if enable_nested_fields is not None:
+                schema['enable_nested_fields'] = enable_nested_fields
+
         self.typesense_client.collections.create(schema)
 
     def add_records(self, records, url, from_sitemap):


### PR DESCRIPTION
## Change Summary

Typesense has supported since v24: https://typesense.org/docs/28.0/api/collections.html#notes-on-indexing-common-types-of-data

When using the [typesense-docsearch-scraper](https://github.com/typesense/typesense-docsearch-scraper) , "enabled_nested_fields" is ignored.

This PR makes sure the "enabled_nested_fields" is read and effective when creating a collection.

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
