### PR TITLE
Add IPv6 support

### DIFF
--- a/scraper/src/config/config_loader.py
+++ b/scraper/src/config/config_loader.py
@@ -28,7 +28,7 @@ class ConfigLoader:
     api_key = None
     app_id = None
     custom_settings = None
-    dns_resolver = 'scrapy.resolver.CachingThreadedResolver'
+    dns_resolver = None
     extra_records = []
     index_name = None
     index_name_tmp = None

--- a/scraper/src/index.py
+++ b/scraper/src/index.py
@@ -95,7 +95,7 @@ def run_config(config):
 
     DEFAULT_REQUEST_HEADERS = headers
 
-    process = CrawlerProcess({
+    crawler_settings = {
         'LOG_ENABLED': '1',
         'LOG_LEVEL': 'ERROR',
         'USER_AGENT': config.user_agent,
@@ -105,9 +105,13 @@ def run_config(config):
         # Use our custom dupefilter in order to be scheme agnostic regarding link provided
         'DUPEFILTER_CLASS': DUPEFILTER_CLASS_PATH,
         'DEFAULT_REQUEST_HEADERS': DEFAULT_REQUEST_HEADERS,
-        'TELNETCONSOLE_ENABLED': False,
-        'DNS_RESOLVER': config.dns_resolver
-    })
+        'TELNETCONSOLE_ENABLED': False
+    }
+
+    if config.dns_resolver is not None:
+        crawler_settings['DNS_RESOLVER'] = config.dns_resolver
+
+    process = CrawlerProcess(crawler_settings)
 
     process.crawl(
         DocumentationSpider,


### PR DESCRIPTION
## Change Summary
According to the Scrapy [documentation](https://docs.scrapy.org/en/latest/topics/settings.html#dns-resolver) it supports only IPv4 by default. Luckily there is a setting that allows you to change dns resolver to the one which supports IPv6. I added ability to specify dns resolver in docsearch-scrapper config.

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
