### PR TITLE
chore: able to config timeout/retry/health_check number via environment

### DIFF
--- a/scraper/src/typesense_helper.py
+++ b/scraper/src/typesense_helper.py
@@ -26,6 +26,8 @@ class TypesenseHelper:
                 ],
                 'connection_timeout_seconds': int(os.environ.get('TYPESENSE_CONNECTION_TIMEOUT_SECONDS', 30 * 60)),
                 'retry_interval_seconds': int(os.environ.get('TYPESENSE_RETRY_INTERVAL_SECONDS', 1)),
+                'num_retries': int(os.environ.get('TYPESENSE_NUM_RETRIES', 3)),
+                'healthcheck_interval_seconds': int(os.environ.get('TYPESENSE_HEALTHCHECK_INTERVAL_SECONDS', 60)),
                 'verify': os.environ.get('TYPESENSE_VERIFY', 'True').lower() == 'true',
             }
         )

--- a/scraper/src/typesense_helper.py
+++ b/scraper/src/typesense_helper.py
@@ -24,7 +24,8 @@ class TypesenseHelper:
                         'protocol': os.environ.get('TYPESENSE_PROTOCOL', None),
                     }
                 ],
-                'connection_timeout_seconds': 30 * 60,
+                'connection_timeout_seconds': int(os.environ.get('TYPESENSE_CONNECTION_TIMEOUT_SECONDS', 30 * 60)),
+                'retry_interval_seconds': int(os.environ.get('TYPESENSE_RETRY_INTERVAL_SECONDS', 1)),
                 'verify': os.environ.get('TYPESENSE_VERIFY', 'True').lower() == 'true',
             }
         )


### PR DESCRIPTION
## Change Summary
Able to config timeout/retry/health_check number via environment https://github.com/typesense/typesense-python/blob/master/src/typesense/configuration.py#L211C14-L218
<img width="2426" height="402" alt="image" src="https://github.com/user-attachments/assets/4837e470-f684-4e0f-bb72-79d9a1fb94a3" />


## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
